### PR TITLE
Highlight key skills with logo section

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -723,12 +723,12 @@ main {
 
 
 /**
- * #clients 
+ * #skill-logos
  */
 
-.clients { margin-bottom: 15px; }
+.skill-logos { margin-bottom: 15px; }
 
-.clients-list {
+.skill-logos-list {
   display: flex;
   justify-content: flex-start;
   align-items: flex-start;
@@ -743,18 +743,18 @@ main {
   scroll-padding-inline: 25px;
 }
 
-.clients-item {
+.skill-logos-item {
   min-width: 50%;
   scroll-snap-align: start;
 }
 
-.clients-item img {
+.skill-logos-item img {
   width: 100%;
   filter: grayscale(1);
   transition: var(--transition-1);
 }
 
-.clients-item img:hover { filter: grayscale(0); }
+.skill-logos-item img:hover { filter: grayscale(0); }
 
 
 
@@ -1148,10 +1148,10 @@ main {
 @media (min-width: 450px) {
 
   /**
-   * client
+   * skill logo
    */
 
-  .clients-item { min-width: calc(33.33% - 10px); }
+  .skill-logos-item { min-width: calc(33.33% - 10px); }
 
 
 
@@ -1383,16 +1383,16 @@ main {
     width: 35px;
   }
 
-  /* clients */
+  /* skill logos */
 
-  .clients-list {
+  .skill-logos-list {
     gap: 50px;
     margin: 0 -30px;
     padding: 45px;
     scroll-padding-inline: 45px;
   }
 
-  .clients-item { min-width: calc(33.33% - 35px); }
+  .skill-logos-item { min-width: calc(33.33% - 35px); }
 
 
 
@@ -1646,9 +1646,9 @@ main {
 
   .testimonials-item { min-width: calc(50% - 15px); }
 
-  /* clients */
+  /* skill logos */
 
-  .clients-item { min-width: calc(25% - 38px); }
+  .skill-logos-item { min-width: calc(25% - 38px); }
 
 
 

--- a/index.html
+++ b/index.html
@@ -419,48 +419,48 @@
 
 
         <!--
-          - clients
+          - skills
         -->
 
-        <section class="clients">
+        <section class="skill-logos">
 
-          <h3 class="h3 clients-title">Clients</h3>
+          <h3 class="h3 skills-title">Skills</h3>
 
-          <ul class="clients-list has-scrollbar">
+          <ul class="skill-logos-list has-scrollbar">
 
-            <li class="clients-item">
+            <li class="skill-logos-item">
               <a href="#">
-                <img src="./assets/images/logo-1-color.png" alt="client logo">
+                <img src="https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/python.svg" alt="Python logo">
               </a>
             </li>
 
-            <li class="clients-item">
+            <li class="skill-logos-item">
               <a href="#">
-                <img src="./assets/images/logo-2-color.png" alt="client logo">
+                <img src="https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/cplusplus.svg" alt="C++ logo">
               </a>
             </li>
 
-            <li class="clients-item">
+            <li class="skill-logos-item">
               <a href="#">
-                <img src="./assets/images/logo-3-color.png" alt="client logo">
+                <img src="https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/matlab.svg" alt="MATLAB logo">
               </a>
             </li>
 
-            <li class="clients-item">
+            <li class="skill-logos-item">
               <a href="#">
-                <img src="./assets/images/logo-4-color.png" alt="client logo">
+                <img src="https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/arduino.svg" alt="Arduino logo">
               </a>
             </li>
 
-            <li class="clients-item">
+            <li class="skill-logos-item">
               <a href="#">
-                <img src="./assets/images/logo-5-color.png" alt="client logo">
+                <img src="https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/solidworks.svg" alt="SolidWorks logo">
               </a>
             </li>
 
-            <li class="clients-item">
+            <li class="skill-logos-item">
               <a href="#">
-                <img src="./assets/images/logo-6-color.png" alt="client logo">
+                <img src="https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/ieee.svg" alt="IEEE logo">
               </a>
             </li>
 


### PR DESCRIPTION
## Summary
- Replace 'Clients' section on About tab with 'Skills' and showcase Python, C++, MATLAB, Arduino, SolidWorks, and IEEE logos via external images
- Adjust styling and responsive layouts for new skill logos section

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689607bf8ca8832384ae5c50a9210c12