### PR TITLE
Refine skill icons

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -515,17 +515,15 @@ main {
 }
 
 .skill-logos-item {
-  min-width: 50%;
+  min-width: 40px;
   scroll-snap-align: start;
 }
 
 .skill-logos-item img {
-  width: 100%;
-  filter: grayscale(1);
+  width: 40px;
+  height: 40px;
   transition: var(--transition-1);
 }
-
-.skill-logos-item img:hover { filter: grayscale(0); }
 
 
 
@@ -839,7 +837,7 @@ main {
    * skill logo
    */
 
-  .skill-logos-item { min-width: calc(33.33% - 10px); }
+  .skill-logos-item { min-width: 40px; }
 
 
 
@@ -998,7 +996,7 @@ main {
     scroll-padding-inline: 45px;
   }
 
-  .skill-logos-item { min-width: calc(33.33% - 35px); }
+  .skill-logos-item { min-width: 40px; }
 
 
 
@@ -1231,7 +1229,7 @@ main {
 
   /* skill logos */
 
-  .skill-logos-item { min-width: calc(25% - 38px); }
+  .skill-logos-item { min-width: 40px; }
 
 
 

--- a/index.html
+++ b/index.html
@@ -201,37 +201,37 @@
 
             <li class="skill-logos-item">
               <a href="#">
-                <img src="https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/python.svg" alt="Python logo">
+                <img src="https://cdn.simpleicons.org/python/00843d" alt="Python logo">
               </a>
             </li>
 
             <li class="skill-logos-item">
               <a href="#">
-                <img src="https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/cplusplus.svg" alt="C++ logo">
+                <img src="https://cdn.simpleicons.org/cplusplus/00843d" alt="C++ logo">
               </a>
             </li>
 
             <li class="skill-logos-item">
               <a href="#">
-                <img src="https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/matlab.svg" alt="MATLAB logo">
+                <img src="https://cdn.simpleicons.org/matlab/00843d" alt="MATLAB logo">
               </a>
             </li>
 
             <li class="skill-logos-item">
               <a href="#">
-                <img src="https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/arduino.svg" alt="Arduino logo">
+                <img src="https://cdn.simpleicons.org/arduino/00843d" alt="Arduino logo">
               </a>
             </li>
 
             <li class="skill-logos-item">
               <a href="#">
-                <img src="https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/solidworks.svg" alt="SolidWorks logo">
+                <img src="https://cdn.simpleicons.org/solidworks/00843d" alt="SolidWorks logo">
               </a>
             </li>
 
             <li class="skill-logos-item">
               <a href="#">
-                <img src="https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/ieee.svg" alt="IEEE logo">
+                <img src="https://cdn.simpleicons.org/ieee/00843d" alt="IEEE logo">
               </a>
             </li>
 


### PR DESCRIPTION
## Summary
- shrink skill logos to consistent 40px size
- unify skill logo color to site green
- ensure MATLAB and SolidWorks logos load from Simple Icons

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ab7156a208323b61c1af486ef00d8