### PR TITLE
Use external links for project images

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -732,11 +732,12 @@ main {
   100% { transform: scale(1); }
 }
 
-.project-item > a { width: 100%; }
+.project-item > a { width: 100%; max-width: 600px; }
 
 .project-img {
   position: relative;
   width: 100%;
+  max-width: 600px;
   height: 200px;
   border-radius: 16px;
   overflow: hidden;
@@ -847,7 +848,7 @@ main {
      * #PORTFOLIO
      */
 
-    .project-img { height: auto; }
+    .project-img { height: 450px; }
 
 }
 

--- a/index.html
+++ b/index.html
@@ -649,7 +649,7 @@
                     <ion-icon name="eye-outline"></ion-icon>
                   </div>
 
-                  <img src="./assets/images/project-1.jpg" alt="Crossing Notre Dame Game screenshot" loading="lazy">
+                  <img src="https://media.licdn.com/dms/image/v2/D4D2DAQEs09-U8fQH4g/profile-treasury-image-shrink_800_800/B4DZiJ2PB8HYAY-/0/1754659440663?e=1755576000&amp;v=beta&amp;t=AcJUMf3_y22dvduA4RY1hNH-R6MNoliPIWhAxVPh87w" alt="Crossing Notre Dame Game screenshot" loading="lazy" width="600" height="450">
                 </figure>
 
                 <h3 class="project-title">Crossing Notre Dame Game</h3>
@@ -667,7 +667,7 @@
                     <ion-icon name="eye-outline"></ion-icon>
                   </div>
 
-                  <img src="./assets/images/project-2.png" alt="Bomb Detection Robot" loading="lazy">
+                  <img src="https://media.licdn.com/dms/image/v2/D4D2DAQFeuZJriZEoZw/profile-treasury-image-shrink_1280_1280/B4DZiZkWpVHYAU-/0/1754923102957?e=1755576000&amp;v=beta&amp;t=cRvOEJsuY6xeMgdLB-29P2Si8BteasX23cSHPUHy0C0" alt="Bomb Detection Robot" loading="lazy" width="600" height="450">
                 </figure>
 
                 <h3 class="project-title">Bomb Detection Robot</h3>
@@ -685,7 +685,7 @@
                     <ion-icon name="eye-outline"></ion-icon>
                   </div>
 
-                  <img src="./assets/images/project-3.jpg" alt="Stock Data Analysis App" loading="lazy">
+                  <img src="https://media.licdn.com/dms/image/v2/D4D2DAQFw8OFaYyFN9w/profile-treasury-image-shrink_800_800/B4DZiJ6EJzGQAY-/0/1754660362672?e=1755576000&amp;v=beta&amp;t=MkTn3ac9NxqGUm8y-xhog5TToelhQJLHTYJO1yYf6vg" alt="Stock Data Analysis App" loading="lazy" width="600" height="450">
                 </figure>
 
                 <h3 class="project-title">Stock Data Analysis App</h3>
@@ -703,7 +703,7 @@
                     <ion-icon name="eye-outline"></ion-icon>
                   </div>
 
-                  <img src="./assets/images/project-4.png" alt="Air Quality Sensor Housing" loading="lazy">
+                  <img src="https://media.licdn.com/dms/image/v2/D4D2DAQEkO1XfNk6gAQ/profile-treasury-image-shrink_800_800/B4DZiJ1IDLGQAY-/0/1754659094261?e=1755576000&amp;v=beta&amp;t=Na-sq0fvGN0kmG20kxpYNaUxmGSOeoSqkHvEBiZv34Q" alt="Air Quality Sensor Housing" loading="lazy" width="600" height="450">
                 </figure>
 
                 <h3 class="project-title">Air Quality Sensor Housing</h3>
@@ -721,7 +721,7 @@
                     <ion-icon name="eye-outline"></ion-icon>
                   </div>
 
-                  <img src="./assets/images/project-5.png" alt="Custom Guitar Pedal and Laser-Cut Casing" loading="lazy">
+                  <img src="https://media.licdn.com/dms/image/v2/D4D2DAQFHGjLln7n74w/profile-treasury-image-shrink_800_800/B4DZiJ0aQ6HsAc-/0/1754658882214?e=1755576000&amp;v=beta&amp;t=356QwcWzSY82Pl9Bym9rfdJ8cGXuL73wMMnU4ldgCPE" alt="Custom Guitar Pedal and Laser-Cut Casing" loading="lazy" width="600" height="450">
                 </figure>
 
                 <h3 class="project-title">Custom Guitar Pedal and Laser-Cut Casing</h3>


### PR DESCRIPTION
## Summary
- Replace local project images with user-provided external links for Crossing Notre Dame Game, Bomb Detection Robot, Stock Data Analysis App, Air Quality Sensor Housing, and Custom Guitar Pedal
- Size project images uniformly at 600x450 to match the original rectangular format

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ab83cac6c83238c34636411bb56db